### PR TITLE
build Android arm64-v8a wheel

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -119,10 +119,119 @@ jobs:
         with:
           name: tinymesa-whl-${{ matrix.tag }}-${{ matrix.os }}
           path: dist/
+  android:
+    name: Build tinymesa mesa-25.2.7 for Android arm64-v8a
+    runs-on: ubuntu-22.04
+    env:
+      MESA_TAG: mesa-25.2.7
+      ANDROID_API: '25'
+      NDK_VERSION: 29.0.14206865
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup tinymesa
+        uses: ./.github/actions/setup
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+      - name: Install Android NDK
+        run: sdkmanager "ndk;${NDK_VERSION}"
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.88.0
+          targets: aarch64-linux-android
+      - name: Install bindgen
+        run: cargo install --locked --version 0.72.1 bindgen-cli
+      - name: Clone mesa
+        run: git clone --depth 1 --branch ${MESA_TAG} https://gitlab.freedesktop.org/mesa/mesa.git ${{ github.workspace }}/mesa
+      - name: Build host mesa_clc
+        run: |
+          cd ${{ github.workspace }}/mesa
+          export CLANG_PATH=$(which clang-20)
+          meson setup build-compiler \
+            -Dprefix=${{ runner.temp }}/mesa-compiler \
+            -Dbuildtype=release \
+            -Dstrip=true \
+            -Dplatforms="[]" \
+            -Dgallium-drivers="[]" \
+            -Dvulkan-drivers="[]" \
+            -Dmesa-clc=enabled \
+            -Dinstall-mesa-clc=true
+          meson install -C build-compiler
+          echo "${{ runner.temp }}/mesa-compiler/bin" >> "$GITHUB_PATH"
+      - name: Patch mesa
+        run: ./apply_patches.py ${{ github.workspace }}/mesa ${MESA_TAG}
+      - name: Build Android wheel
+        env:
+          LIBCLANG_PATH: /usr/lib/llvm-20/lib
+        run: |
+          NDK=${ANDROID_SDK_ROOT}/ndk/${NDK_VERSION}
+          TOOLCHAIN=${NDK}/toolchains/llvm/prebuilt/linux-x86_64
+          cat > ${{ runner.temp }}/android-aarch64.ini <<EOF
+          [binaries]
+          ar = '${TOOLCHAIN}/bin/llvm-ar'
+          c = '${TOOLCHAIN}/bin/aarch64-linux-android${ANDROID_API}-clang'
+          cpp = ['${TOOLCHAIN}/bin/aarch64-linux-android${ANDROID_API}-clang++', '-fno-exceptions', '-fno-unwind-tables', '-fno-asynchronous-unwind-tables', '--start-no-unused-arguments', '-static-libstdc++', '--end-no-unused-arguments']
+          c_ld = 'lld'
+          cpp_ld = 'lld'
+          strip = '${TOOLCHAIN}/bin/llvm-strip'
+          rust = ['rustc', '--target', 'aarch64-linux-android']
+
+          [host_machine]
+          system = 'android'
+          cpu_family = 'aarch64'
+          cpu = 'armv8'
+          endian = 'little'
+
+          [properties]
+          needs_exe_wrapper = true
+          bindgen_clang_arguments = ['-target', 'aarch64-linux-android', '--sysroot', '${TOOLCHAIN}/sysroot']
+          EOF
+
+          cd ${{ github.workspace }}/mesa
+          export CLANG_PATH=$(which clang-20)
+          meson setup build-android \
+            --cross-file=${{ runner.temp }}/android-aarch64.ini \
+            -Dbuildtype=release \
+            -Db_ndebug=true \
+            -Db_staticpic=true \
+            -Dplatforms=android \
+            -Dplatform-sdk-version=${ANDROID_API} \
+            -Dandroid-stub=true \
+            -Dandroid-strict=false \
+            -Dandroid-libbacktrace=disabled \
+            -Dgallium-drivers="[]" \
+            -Dvulkan-drivers=freedreno,nouveau \
+            -Dfreedreno-kmds=kgsl \
+            -Dallow-fallback-for=libdrm \
+            -Dmesa-clc=system \
+            -Dllvm=disabled \
+            -Dshader-cache=disabled \
+            -Dzstd=disabled \
+            -Dzlib=disabled \
+            -Dopengl=false \
+            -Degl=disabled \
+            -Dgbm=disabled \
+            -Dvideo-codecs="[]"
+          meson compile -C build-android tinymesa
+          LIB=$(realpath "$(meson introspect build-android --targets | jq -er '.[] | select(.name=="tinymesa") | .filename[0]')")
+          ${TOOLCHAIN}/bin/llvm-readelf -h "$LIB" | grep -q AArch64
+          ${TOOLCHAIN}/bin/llvm-nm -D --defined-only "$LIB" | grep -q ' nak_compiler_create$'
+          ${TOOLCHAIN}/bin/llvm-nm -D --defined-only "$LIB" | grep -q ' ir3_compile_shader_nir$'
+
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then VERSION_ARG=(--tag "$GITHUB_REF_NAME"); else VERSION_ARG=(--sha "${GITHUB_SHA::7}"); fi
+          cd ${{ github.workspace }}
+          ./build_wheel.py "${VERSION_ARG[@]}" --platform android_${ANDROID_API}_arm64_v8a ${MESA_TAG} "$LIB"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tinymesa-whl-mesa-25.2.7-android-arm64-v8a
+          path: dist/
+
   release:
     name: Release tinymesa
     runs-on: ubuntu-22.04
-    needs: tinymesa
+    needs: [ tinymesa, android ]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     environment:
       name: pypi

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -120,12 +120,8 @@ jobs:
           name: tinymesa-whl-${{ matrix.tag }}-${{ matrix.os }}
           path: dist/
   android:
-    name: Build tinymesa mesa-25.2.7 for Android arm64-v8a
+    name: Build tinymesa mesa-25.2.7 on Android arm64
     runs-on: ubuntu-22.04
-    env:
-      MESA_TAG: mesa-25.2.7
-      ANDROID_API: '25'
-      NDK_VERSION: 29.0.14206865
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -134,94 +130,43 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
       - name: Install Android NDK
-        run: sdkmanager "ndk;${NDK_VERSION}"
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.88.0
-          targets: aarch64-linux-android
-      - name: Install bindgen
-        run: cargo install --locked --version 0.72.1 bindgen-cli
+        run: sdkmanager "ndk;29.0.14206865"
       - name: Clone mesa
-        run: git clone --depth 1 --branch ${MESA_TAG} https://gitlab.freedesktop.org/mesa/mesa.git ${{ github.workspace }}/mesa
-      - name: Build host mesa_clc
-        run: |
-          cd ${{ github.workspace }}/mesa
-          export CLANG_PATH=$(which clang-20)
-          meson setup build-compiler \
-            -Dprefix=${{ runner.temp }}/mesa-compiler \
-            -Dbuildtype=release \
-            -Dstrip=true \
-            -Dplatforms="[]" \
-            -Dgallium-drivers="[]" \
-            -Dvulkan-drivers="[]" \
-            -Dmesa-clc=enabled \
-            -Dinstall-mesa-clc=true
-          meson install -C build-compiler
-          echo "${{ runner.temp }}/mesa-compiler/bin" >> "$GITHUB_PATH"
+        run: git clone --depth 1 --branch mesa-25.2.7 https://gitlab.freedesktop.org/mesa/mesa.git ${{ github.workspace }}/mesa
       - name: Patch mesa
-        run: ./apply_patches.py ${{ github.workspace }}/mesa ${MESA_TAG}
-      - name: Build Android wheel
-        env:
-          LIBCLANG_PATH: /usr/lib/llvm-20/lib
+        run: ./apply_patches.py ${{ github.workspace }}/mesa mesa-25.2.7
+      - name: Build mesa
+        shell: bash
         run: |
-          NDK=${ANDROID_SDK_ROOT}/ndk/${NDK_VERSION}
-          TOOLCHAIN=${NDK}/toolchains/llvm/prebuilt/linux-x86_64
-          cat > ${{ runner.temp }}/android-aarch64.ini <<EOF
+          TOOLCHAIN=${ANDROID_SDK_ROOT}/ndk/29.0.14206865/toolchains/llvm/prebuilt/linux-x86_64
+          cat > ${{ runner.temp }}/android.ini <<EOF
           [binaries]
           ar = '${TOOLCHAIN}/bin/llvm-ar'
-          c = '${TOOLCHAIN}/bin/aarch64-linux-android${ANDROID_API}-clang'
-          cpp = ['${TOOLCHAIN}/bin/aarch64-linux-android${ANDROID_API}-clang++', '-fno-exceptions', '-fno-unwind-tables', '-fno-asynchronous-unwind-tables', '--start-no-unused-arguments', '-static-libstdc++', '--end-no-unused-arguments']
-          c_ld = 'lld'
-          cpp_ld = 'lld'
+          c = '${TOOLCHAIN}/bin/aarch64-linux-android25-clang'
+          cpp = '${TOOLCHAIN}/bin/aarch64-linux-android25-clang++'
           strip = '${TOOLCHAIN}/bin/llvm-strip'
-          rust = ['rustc', '--target', 'aarch64-linux-android']
-
           [host_machine]
           system = 'android'
           cpu_family = 'aarch64'
           cpu = 'armv8'
           endian = 'little'
-
           [properties]
           needs_exe_wrapper = true
-          bindgen_clang_arguments = ['-target', 'aarch64-linux-android', '--sysroot', '${TOOLCHAIN}/sysroot']
           EOF
-
           cd ${{ github.workspace }}/mesa
-          export CLANG_PATH=$(which clang-20)
-          meson setup build-android \
-            --cross-file=${{ runner.temp }}/android-aarch64.ini \
-            -Dbuildtype=release \
-            -Db_ndebug=true \
-            -Db_staticpic=true \
-            -Dplatforms=android \
-            -Dplatform-sdk-version=${ANDROID_API} \
-            -Dandroid-stub=true \
-            -Dandroid-strict=false \
-            -Dandroid-libbacktrace=disabled \
-            -Dgallium-drivers="[]" \
-            -Dvulkan-drivers=freedreno,nouveau \
-            -Dfreedreno-kmds=kgsl \
-            -Dallow-fallback-for=libdrm \
-            -Dmesa-clc=system \
-            -Dllvm=disabled \
-            -Dshader-cache=disabled \
-            -Dzstd=disabled \
-            -Dzlib=disabled \
-            -Dopengl=false \
-            -Degl=disabled \
-            -Dgbm=disabled \
-            -Dvideo-codecs="[]"
-          meson compile -C build-android tinymesa
-          LIB=$(realpath "$(meson introspect build-android --targets | jq -er '.[] | select(.name=="tinymesa") | .filename[0]')")
-          ${TOOLCHAIN}/bin/llvm-readelf -h "$LIB" | grep -q AArch64
-          ${TOOLCHAIN}/bin/llvm-nm -D --defined-only "$LIB" | grep -q ' nak_compiler_create$'
-          ${TOOLCHAIN}/bin/llvm-nm -D --defined-only "$LIB" | grep -q ' ir3_compile_shader_nir$'
+          meson setup build/ --cross-file=${{ runner.temp }}/android.ini -Db_staticpic=true -Dplatforms=android -Dplatform-sdk-version=25 -Dandroid-stub=true -Dandroid-libbacktrace=disabled -Dgallium-drivers="[]" -Dvulkan-drivers=freedreno -Dfreedreno-kmds=kgsl -Dllvm=disabled -Dshader-cache=disabled -Dzstd=disabled -Dzlib=disabled -Dopengl=false -Degl=disabled -Dgbm=disabled -Dvideo-codecs="[]"
+          meson compile -C build tinymesa
+      - name: Build wheel
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION_ARG=(--tag "$GITHUB_REF_NAME")
+          else
+            VERSION_ARG=(--sha "${GITHUB_SHA::7}")
+          fi
 
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then VERSION_ARG=(--tag "$GITHUB_REF_NAME"); else VERSION_ARG=(--sha "${GITHUB_SHA::7}"); fi
-          cd ${{ github.workspace }}
-          ./build_wheel.py "${VERSION_ARG[@]}" --platform android_${ANDROID_API}_arm64_v8a ${MESA_TAG} "$LIB"
+          ./build_wheel.py "${VERSION_ARG[@]}" \
+            --platform android_25_arm64_v8a \
+            mesa-25.2.7 ${{ github.workspace }}/mesa/build/src/tinymesa/libtinymesa.so
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -82,3 +82,9 @@ all these symbols, but in addition, a subset of symbols from `gallium`
 (see release notes), and as a result depends on LLVM-20.
 
 Builds are automatically generated upon new releases of mesa (checked daily).
+
+### Android
+
+Android `arm64-v8a` wheels target API 25 and contain `libtinymesa.so` with
+the same NIR, NAK, and IR3 compiler API as the desktop build. The optional
+LLVMpipe-based `libtinymesa_cpu.so` is not included.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,4 @@ Builds are automatically generated upon new releases of mesa (checked daily).
 
 ### Android
 
-Android `arm64-v8a` wheels target API 25 and contain `libtinymesa.so` with
-the same NIR, NAK, and IR3 compiler API as the desktop build. The optional
-LLVMpipe-based `libtinymesa_cpu.so` is not included.
+Android arm64 wheels target API 25 and include NIR and IR3 support. NAK and LLVMpipe are not included.

--- a/meson.build
+++ b/meson.build
@@ -52,6 +52,10 @@ foreach sym : ir3_symbols
   ir3_link_args += '-Wl,-u,' + symbol_prefix + sym
 endforeach
 
-shared_library('tinymesa', link_whole : [ _libnir ], link_args : nak_link_args+ir3_link_args, link_with : [ libfreedreno_ir3, libfreedreno_common ], dependencies : [ idep_nak ])
-shared_library('tinymesa_cpu', link_whole : [ _libnir ], link_args : lvp_link_args+nak_link_args+ir3_link_args, link_with : [ libfreedreno_ir3, libfreedreno_common, libgallium ], dependencies : [ idep_nak ])
+if host_machine.system() == 'android'
+  shared_library('tinymesa', link_whole : [ _libnir ], link_args : ir3_link_args, link_with : [ libfreedreno_ir3, libfreedreno_common ])
+else
+  shared_library('tinymesa', link_whole : [ _libnir ], link_args : nak_link_args+ir3_link_args, link_with : [ libfreedreno_ir3, libfreedreno_common ], dependencies : [ idep_nak ])
+  shared_library('tinymesa_cpu', link_whole : [ _libnir ], link_args : lvp_link_args+nak_link_args+ir3_link_args, link_with : [ libfreedreno_ir3, libfreedreno_common, libgallium ], dependencies : [ idep_nak ])
+endif
 


### PR DESCRIPTION
adds an android arm64-v8a build for the normal libtinymesa.so.

* targets android api 25 using ndk r29, since api 25 is the minimum supported by mesa 25.2.7 (26.1.4 needs api 29)
* builds against mesa 25.2.7
* builds the host mesa_clc tool first since nak needs it during the cross compile
* does some basic validation to make sure the library was built for the correct architecture and still exports the expected nak + ir3 symbols

libtinymesa_cpu.so is omitted because it is only needed for the optional LLVMpipe CPU backend. ig we dont really need nak either for normal android phones, but keeping it gives us a complete libtinymesa.so build on android. someone could also theoretically be running android on an arm board with nvidia hardware. anyways it was simple enough to keep.

the cpu build is more annoying because we would need to cross compile llvm 20 for android arm64. the llvm installed on the ubuntu runner is an x86_64 linux build, so it cant be linked into the android library. we could probably cheat by using a termux llvm binary, but then the build would most likely only work inside termux instead of being a normal android wheel.

i used codex for some of the workflow setup since i wasnt very familiar with github build workflows and had to translate my local build script. tested locally and it works fine.
